### PR TITLE
build: basic debt allocator

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,8 @@ jobs:
       - uses: ApeWorX/github-action@v2
         with:
           python-version: '3.10'
+          ape-version-pin: "==0.6.8"
+          ape-plugins-list: 'solidity==0.6.3 vyper==0.6.5 hardhat==0.6.4 infura==0.6.1 etherscan==0.6.4'
       - name: install vyper
         run: pip install git+https://github.com/vyperlang/vyper
       - run: ape compile --force --size

--- a/contracts/debtAllocators/GenericDebtAllocator.sol
+++ b/contracts/debtAllocators/GenericDebtAllocator.sol
@@ -7,65 +7,118 @@ import {Governance} from "@periphery/utils/Governance.sol";
 import {IVault} from "../interfaces/IVault.sol";
 
 contract GenericDebtAllocator is Governance {
+    event SetTargetDebtRatio(
+        address indexed strategy,
+        uint256 targetRatio,
+        uint256 totalDebtRatio
+    );
+
+    event SetMinimumChange(address indexed strategy, uint256 minimumChange);
+
+    // Struct for each strategies info.
     struct Config {
-        bool active;
         uint256 targetRatio;
         uint256 minimumChange;
     }
 
     uint256 internal constant MAX_BPS = 10_000;
 
-    mapping(address => mapping(address => Config)) public configs;
+    // Mapping of strategy => its config.
+    mapping(address => Config) public configs;
 
-    constructor(address _governance) Governance(_governance) {}
+    // Address of the vault this serves as allocator for.
+    address public vault;
 
+    // Total debt ratio currently allocated in basis points.
+    // Can't be more than 10_000.
+    uint256 public debtRatio;
+
+    constructor(address _vault, address _governance) Governance(_governance) {
+        inizialize(_vault, _governance);
+    }
+
+    /**
+     * @notice Initializes the debt allocator.
+     * @dev Should be called atomiclly after cloning.
+     * @param _vault Address of the vault this allocates debt for.
+     * @param _governance Address to govern this contracts.
+     */
+    function inizialize(address _vault, address _governance) public {
+        require(address(vault) == address(0), "!initialized");
+        vault = _vault;
+        governance = _governance;
+    }
+
+    /**
+     * @notice Check if a strategies debt should be updated.
+     * @dev This should be called by a keeper to decide if a strategies
+     * debt should be updated and if so by how much.
+     *
+     * This cannot be used to withdraw down to 0 debt.
+     *
+     * @param _strategy Address of the strategy to check.
+     * @return . bool repersenting if the debt should be updated.
+     * @return . calldata that includes what the debt should be updated to.
+     */
     function shouldUpdateDebt(
-        address _vault,
         address _strategy
     ) external view returns (bool, bytes memory) {
-        IVault vault = IVault(_vault);
-        IVault.StrategyParams memory params = vault.strategies(_strategy);
-        require(params.activation != 0, "!activated");
+        // Cache the vault variable.
+        IVault _vault = IVault(vault);
+        // Retrieve the strategy specifc parameters.
+        IVault.StrategyParams memory params = _vault.strategies(_strategy);
+        // Make sure its an active strategy.
+        require(params.activation != 0, "!active");
 
-        Config memory config = configs[_vault][_strategy];
-        require(config.active, "!active");
+        // Get the strategy specific debt config.
+        Config memory config = configs[_strategy];
+        // Make sure we have a target debt.
+        require(config.targetRatio != 0, "!target");
 
+        // Get the target debt for the strategy based on vault assets.
         uint256 targetDebt = Math.min(
-            (vault.totalAssets() * config.targetRatio) / MAX_BPS,
+            (_vault.totalAssets() * config.targetRatio) / MAX_BPS,
+            // Make sure it is not more than the max allowed.
             params.max_debt
         );
 
+        // If we need to add more.
         if (targetDebt > params.current_debt) {
+            // We can't add more than the current idle.
             uint256 toAdd = Math.min(
                 targetDebt - params.current_debt,
-                vault.totalIdle() - vault.minimum_total_idle()
+                // This may underflow if idle is less than the min.
+                // Thats okay since it should return false anyway.
+                _vault.totalIdle() - _vault.minimum_total_idle()
             );
 
-            uint256 newDebt = Math.min(
-                params.current_debt + toAdd,
-                params.max_debt
-            );
-
+            // If the amount to add is over our threshold.
             if (toAdd > config.minimumChange) {
+                // Return true and the calldata.
                 return (
                     true,
                     abi.encodeWithSelector(
-                        vault.update_debt.selector,
-                        abi.encode(_strategy, newDebt)
+                        _vault.update_debt.selector,
+                        abi.encode(_strategy, params.current_debt + toAdd)
                     )
                 );
             }
+            // If target debt is lower than the current.
         } else if (targetDebt < params.current_debt) {
+            // Find out by how much.
             uint256 toPull = Math.min(
                 params.current_debt - targetDebt,
-                IVault(_strategy).maxWithdraw(_vault)
+                // Account for the current liquidity constraints.
+                IVault(_strategy).maxWithdraw(address(_vault))
             );
 
+            // Check if its over the threshold.
             if (toPull > config.minimumChange) {
+                // If so return true and the calldata.
                 return (
                     true,
                     abi.encodeWithSelector(
-                        vault.update_debt.selector,
+                        _vault.update_debt.selector,
                         abi.encode(_strategy, params.current_debt - toPull)
                     )
                 );
@@ -75,27 +128,56 @@ contract GenericDebtAllocator is Governance {
         }
     }
 
-    function setConfig(
-        address _vault,
+    /**
+     * @notice Sets a new target debt ratio for a strategy.
+     * @dev A `minimumChange` for that strategy must be set first.
+     * This is to prevent debt to be updated to frequently.
+     *
+     * @param _strategy Address of the strategy to set.
+     * @param _targetRatio Amount in Basis points to allocate.
+     */
+    function setTargetDebtRatio(
         address _strategy,
-        uint256 _targetRatio,
-        uint256 _minChange
+        uint256 _targetRatio
     ) external onlyGovernance {
-        configs[_vault][_strategy] = Config({
-            active: true,
-            targetRatio: _targetRatio,
-            minimumChange: _minChange
-        });
+        // Make sure the strategy is added to the vault.
+        require(IVault(vault).strategies(_strategy).activation != 0, "!active");
+        // Make sure a minimumChange has been set.
+        require(configs[_strategy].minimumChange != 0, "!minimum");
+
+        // Get what will be the new total debt ratio.
+        uint256 newDebtRatio = debtRatio -
+            configs[_strategy].targetRatio +
+            _targetRatio;
+
+        // Make sure it is under 100% allocated
+        require(newDebtRatio <= MAX_BPS, "!max");
+
+        // Write to storage.
+        configs[_strategy].targetRatio = _targetRatio;
+        debtRatio = newDebtRatio;
+
+        emit SetTargetDebtRatio(_strategy, _targetRatio, newDebtRatio);
     }
 
-    function removeConfig(
-        address _vault,
-        address _strategy
+    /**
+     * @notice Set the minimum change variable for a strategy.
+     * @dev This is the amount of debt that will needed to be
+     * added or pulled for it to trigger an update.
+     *
+     * @param _strategy The address of the strategy to update.
+     * @param _minimumChange The new minimum to set for the strategy.
+     */
+    function setMinimumChange(
+        address _strategy,
+        uint256 _minimumChange
     ) external onlyGovernance {
-        configs[_vault][_strategy] = Config({
-            active: false,
-            targetRatio: 0,
-            minimumChange: 0
-        });
+        // Make sure the strategy is added to the vault.
+        require(IVault(vault).strategies(_strategy).activation != 0, "!active");
+
+        // Set the new minimum.
+        configs[_strategy].minimumChange = _minimumChange;
+
+        emit SetMinimumChange(_strategy, _minimumChange);
     }
 }

--- a/contracts/debtAllocators/GenericDebtAllocator.sol
+++ b/contracts/debtAllocators/GenericDebtAllocator.sol
@@ -97,9 +97,9 @@ contract GenericDebtAllocator is Governance {
                 // Return true and the calldata.
                 return (
                     true,
-                    abi.encodeWithSelector(
-                        _vault.update_debt.selector,
-                        abi.encode(_strategy, params.current_debt + toAdd)
+                    abi.encodeCall(
+                        _vault.update_debt,
+                        (_strategy, params.current_debt + toAdd)
                     )
                 );
             }
@@ -117,9 +117,9 @@ contract GenericDebtAllocator is Governance {
                 // If so return true and the calldata.
                 return (
                     true,
-                    abi.encodeWithSelector(
-                        _vault.update_debt.selector,
-                        abi.encode(_strategy, params.current_debt - toPull)
+                    abi.encodeCall(
+                        _vault.update_debt,
+                        (_strategy, params.current_debt - toPull)
                     )
                 );
             }

--- a/contracts/debtAllocators/GenericDebtAllocator.sol
+++ b/contracts/debtAllocators/GenericDebtAllocator.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.18;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import {Governance} from "@periphery/utils/Governance.sol";
+import {IVault} from "../interfaces/IVault.sol";
+
+contract GenericDebtAllocator is Governance {
+    struct Config {
+        bool active;
+        uint256 targetRatio;
+        uint256 minimumChange;
+    }
+
+    uint256 internal constant MAX_BPS = 10_000;
+
+    mapping(address => mapping(address => Config)) public configs;
+
+    constructor(address _governance) Governance(_governance) {}
+
+    function shouldUpdateDebt(
+        address _vault,
+        address _strategy
+    ) external view returns (bool, bytes memory) {
+        IVault vault = IVault(_vault);
+        IVault.StrategyParams memory params = vault.strategies(_strategy);
+        require(params.activation != 0, "!activated");
+
+        Config memory config = configs[_vault][_strategy];
+        require(config.active, "!active");
+
+        uint256 targetDebt = Math.min(
+            (vault.totalAssets() * config.targetRatio) / MAX_BPS,
+            params.max_debt
+        );
+
+        if (targetDebt > params.current_debt) {
+            uint256 toAdd = Math.min(
+                targetDebt - params.current_debt,
+                vault.totalIdle() - vault.minimum_total_idle()
+            );
+
+            uint256 newDebt = Math.min(
+                params.current_debt + toAdd,
+                params.max_debt
+            );
+
+            if (toAdd > config.minimumChange) {
+                return (
+                    true,
+                    abi.encodeWithSelector(
+                        vault.update_debt.selector,
+                        abi.encode(_strategy, newDebt)
+                    )
+                );
+            }
+        } else if (targetDebt < params.current_debt) {
+            uint256 toPull = Math.min(
+                params.current_debt - targetDebt,
+                IVault(_strategy).maxWithdraw(_vault)
+            );
+
+            if (toPull > config.minimumChange) {
+                return (
+                    true,
+                    abi.encodeWithSelector(
+                        vault.update_debt.selector,
+                        abi.encode(_strategy, params.current_debt - toPull)
+                    )
+                );
+            }
+        } else {
+            return (false, bytes("No Change Needed"));
+        }
+    }
+
+    function setConfig(
+        address _vault,
+        address _strategy,
+        uint256 _targetRatio,
+        uint256 _minChange
+    ) external onlyGovernance {
+        configs[_vault][_strategy] = Config({
+            active: true,
+            targetRatio: _targetRatio,
+            minimumChange: _minChange
+        });
+    }
+
+    function removeConfig(
+        address _vault,
+        address _strategy
+    ) external onlyGovernance {
+        configs[_vault][_strategy] = Config({
+            active: false,
+            targetRatio: 0,
+            minimumChange: 0
+        });
+    }
+}

--- a/contracts/debtAllocators/GenericDebtAllocatorFactory.sol
+++ b/contracts/debtAllocators/GenericDebtAllocatorFactory.sol
@@ -41,7 +41,7 @@ contract GenericDebtAllocatorFactory {
             newAllocator := create(0, clone_code, 0x37)
         }
 
-        GenericDebtAllocator(newAllocator).inizialize(_vault, _governance);
+        GenericDebtAllocator(newAllocator).initialize(_vault, _governance);
 
         emit NewDebtAllocator(newAllocator, _vault);
     }

--- a/contracts/debtAllocators/GenericDebtAllocatorFactory.sol
+++ b/contracts/debtAllocators/GenericDebtAllocatorFactory.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.18;
+
+import {GenericDebtAllocator} from "./GenericDebtAllocator.sol";
+
+contract GenericDebtAllocatorFactory {
+    event NewDebtAllocator(address indexed allocator, address indexed vault);
+
+    address public immutable original;
+
+    constructor(address _vault, address _governance) {
+        original = address(new GenericDebtAllocator(_vault, _governance));
+
+        emit NewDebtAllocator(original, _vault);
+    }
+
+    function newGenericDebtAllocator(
+        address _vault
+    ) external returns (address) {
+        return newGenericDebtAllocator(_vault, msg.sender);
+    }
+
+    function newGenericDebtAllocator(
+        address _vault,
+        address _governance
+    ) public returns (address newAllocator) {
+        // Copied from https://github.com/optionality/clone-factory/blob/master/contracts/CloneFactory.sol
+        bytes20 addressBytes = bytes20(original);
+        assembly {
+            // EIP-1167 bytecode
+            let clone_code := mload(0x40)
+            mstore(
+                clone_code,
+                0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000
+            )
+            mstore(add(clone_code, 0x14), addressBytes)
+            mstore(
+                add(clone_code, 0x28),
+                0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000
+            )
+            newAllocator := create(0, clone_code, 0x37)
+        }
+
+        GenericDebtAllocator(newAllocator).inizialize(_vault, _governance);
+
+        emit NewDebtAllocator(newAllocator, _vault);
+    }
+}

--- a/contracts/debtAllocators/GenericDebtAllocatorFactory.sol
+++ b/contracts/debtAllocators/GenericDebtAllocatorFactory.sol
@@ -3,9 +3,17 @@ pragma solidity 0.8.18;
 
 import {GenericDebtAllocator} from "./GenericDebtAllocator.sol";
 
+/**
+ * @title YearnV3 Generic Debt Allocator Factory
+ * @author yearn.finance
+ * @notice
+ *  Factory for anyone to easily deploy their own generic
+ *  debt allocator for a Yearn V3 Vault.
+ */
 contract GenericDebtAllocatorFactory {
     event NewDebtAllocator(address indexed allocator, address indexed vault);
 
+    // Original allocator to use for cloning.
     address public immutable original;
 
     constructor(address _vault, address _governance) {
@@ -14,12 +22,25 @@ contract GenericDebtAllocatorFactory {
         emit NewDebtAllocator(original, _vault);
     }
 
+    /**
+     * @notice Clones a new debt allocator.
+     * @dev defaults to msg.sender as the governance role.
+     *
+     * @param _vault The vault for the allocator to be hooked to.
+     * @return Address of the new generic debt allocator
+     */
     function newGenericDebtAllocator(
         address _vault
     ) external returns (address) {
         return newGenericDebtAllocator(_vault, msg.sender);
     }
 
+    /**
+     * @notice Clones a new debt allocator.
+     * @param _vault The vault for the allocator to be hooked to.
+     * @param _governance Address to serve as governance.
+     * @return newAllocator Address of the new generic debt allocator
+     */
     function newGenericDebtAllocator(
         address _vault,
         address _governance

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.18;
+
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+interface IVault is IERC4626 {
+    struct StrategyParams {
+        uint256 activation;
+        uint256 last_report;
+        uint256 current_debt;
+        uint256 max_debt;
+    }
+
+    function strategies(
+        address _strategy
+    ) external view returns (StrategyParams memory);
+
+    function set_role(address, uint256) external;
+
+    function roles(address _address) external view returns (uint256);
+
+    function profitMaxUnlockTime() external view returns (uint256);
+
+    function add_strategy(address) external;
+
+    function update_max_debt_for_strategy(address, uint256) external;
+
+    function update_debt(address, uint256) external;
+
+    function set_deposit_limit(uint256) external;
+
+    function shutdown_vault() external;
+
+    function shutdown() external view returns (bool);
+
+    function minimum_total_idle() external view returns (uint256);
+
+    function totalDebt() external view returns (uint256);
+
+    function totalIdle() external view returns (uint256);
+
+    function transfer_role_manager(address role_manager) external;
+
+    function accept_role_manager() external;
+}

--- a/contracts/registry/Registry.sol
+++ b/contracts/registry/Registry.sol
@@ -20,6 +20,17 @@ interface IStrategy {
     function apiVersion() external view returns (string memory);
 }
 
+/**
+ * @title YearnV3 Registry
+ * @author yearn.finance
+ * @notice
+ *  Serves as an on chain registry to track any Yearn
+ *  vaults and strategies that a certain party wants to
+ *  endorse.
+ *
+ *  Can also be used to deploy new vaults of any specific
+ *  API version.
+ */
 contract Registry is Governance {
     event NewEndorsedVault(
         address indexed vault,

--- a/contracts/registry/RegistryFactory.sol
+++ b/contracts/registry/RegistryFactory.sol
@@ -3,6 +3,12 @@ pragma solidity 0.8.18;
 
 import {Registry} from "./Registry.sol";
 
+/**
+ * @title YearnV3 Registry Factory
+ * @author yearn.finance
+ * @notice
+ *  Factory for anyone to easily deploy their own Registry.
+ */
 contract RegistryFactory {
     event NewRegistry(
         address indexed newRegistry,
@@ -10,6 +16,7 @@ contract RegistryFactory {
         string name
     );
 
+    // The release registry to use for all Registries.
     address public immutable releaseRegistry;
 
     constructor(address _releaseRegistry) {
@@ -20,10 +27,22 @@ contract RegistryFactory {
         return "Custom Vault Registry Factory";
     }
 
+    /**
+     * @notice Deploy a new Registry.
+     * @dev Default to msg.sender for governance.
+     * @param _name The name of the new registry.
+     * @return Address of the new Registry.
+     */
     function createNewRegistry(string memory _name) external returns (address) {
         return createNewRegistry(_name, msg.sender);
     }
 
+    /**
+     * @notice Deploy a new Registry.
+     * @param _governance Address to set as goveranance.
+     * @param _name The name of the new registry.
+     * @return Address of the new Registry.
+     */
     function createNewRegistry(
         string memory _name,
         address _governance

--- a/contracts/registry/RegistryFactory.sol
+++ b/contracts/registry/RegistryFactory.sol
@@ -39,8 +39,8 @@ contract RegistryFactory {
 
     /**
      * @notice Deploy a new Registry.
-     * @param _governance Address to set as goveranance.
      * @param _name The name of the new registry.
+     * @param _governance Address to set as goveranance.
      * @return Address of the new Registry.
      */
     function createNewRegistry(

--- a/contracts/registry/ReleaseRegistry.sol
+++ b/contracts/registry/ReleaseRegistry.sol
@@ -7,12 +7,21 @@ interface IFactory {
     function api_version() external view returns (string memory);
 }
 
+/**
+ * @title YearnV3 Release Registry
+ * @author yearn.finance
+ * @notice
+ *  Used by Yearn Governance to track on chain all
+ *  releases of the V3 vaults by API Version.
+ */
 contract ReleaseRegistry is Governance {
     event NewRelease(
         uint256 indexed releaseId,
         address indexed factory,
         string apiVersion
     );
+
+    string public constant name = "Yearn V3 Release Registry";
 
     // The total number of releases that have been deployed
     uint256 public numReleases;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,3 +289,35 @@ def address_provider(deploy_address_provider):
     address_provider = deploy_address_provider()
 
     yield address_provider
+
+
+@pytest.fixture(scope="session")
+def deploy_generic_debt_allocator_factory(project, vault, daddy):
+    def deploy_generic_debt_allocator_factory(initial_vault=vault, gov=daddy):
+        generic_debt_allocator_factory = gov.deploy(
+            project.GenericDebtAllocatorFactory, initial_vault, gov
+        )
+
+        return generic_debt_allocator_factory
+
+    yield deploy_generic_debt_allocator_factory
+
+
+@pytest.fixture(scope="session")
+def generic_debt_allocator_factory(deploy_generic_debt_allocator_factory):
+    generic_debt_allocator_factory = deploy_generic_debt_allocator_factory()
+
+    yield generic_debt_allocator_factory
+
+
+@pytest.fixture(scope="session")
+def generic_debt_allocator(generic_debt_allocator_factory, project, vault, daddy):
+    tx = generic_debt_allocator_factory.newGenericDebtAllocator(
+        vault, daddy, sender=daddy
+    )
+
+    event = list(tx.decode_logs(generic_debt_allocator_factory.NewDebtAllocator))[0]
+
+    generic_debt_allocator = project.GenericDebtAllocator.at(event.allocator)
+
+    yield generic_debt_allocator

--- a/tests/test_generic_debt_allocator.py
+++ b/tests/test_generic_debt_allocator.py
@@ -1,0 +1,95 @@
+import ape
+from ape import chain, project
+from utils.constants import ZERO_ADDRESS, MAX_INT
+
+
+def test_setup(generic_debt_allocator_factory, user, strategy, vault):
+    tx = generic_debt_allocator_factory.newGenericDebtAllocator(vault, user, sender=user)
+
+    events = list(tx.decode_logs(generic_debt_allocator_factory.NewDebtAllocator))
+
+    assert len(events) == 1
+    assert events[0].vault == vault.address
+
+    generic_debt_allocator = project.GenericDebtAllocator.at(events[0].allocator)
+
+    assert generic_debt_allocator.governance() == user
+    assert generic_debt_allocator.vault() == vault.address
+    assert generic_debt_allocator.configs(strategy) == (0, 0)
+    assert generic_debt_allocator.debtRatio() == 0
+    with ape.reverts("!active"):
+        generic_debt_allocator.shouldUpdateDebt(strategy)
+
+
+def test_set_minimum(generic_debt_allocator, daddy, vault, strategy, user):
+    assert generic_debt_allocator.configs(strategy) == (0, 0)
+
+    minimum = int(1e17)
+
+    with ape.reverts("!governance"):
+        generic_debt_allocator.setMinimumChange(
+            strategy, minimum, sender=user
+        )
+
+    with ape.reverts("!active"):
+        generic_debt_allocator.setMinimumChange(
+            strategy, minimum, sender=daddy
+        )
+
+    vault.add_strategy(strategy.address, sender=daddy)
+
+    tx = generic_debt_allocator.setMinimumChange(
+            strategy, minimum, sender=daddy
+        )
+
+    event = list(tx.decode_logs(generic_debt_allocator.SetMinimumChange))[0]
+
+    assert event.strategy == strategy.address
+    assert event.minimumChange == minimum
+    assert generic_debt_allocator.configs(strategy) == (0, minimum)
+
+
+def test_set_minimum(generic_debt_allocator, daddy, vault, strategy, user):
+    assert generic_debt_allocator.configs(strategy) == (0, 0)
+
+    minimum = int(1e17)
+    target = int(5_000)
+
+    with ape.reverts("!governance"):
+        generic_debt_allocator.setTargetDebtRatio(
+            strategy, target, sender=user
+        )
+
+    with ape.reverts("!active"):
+        generic_debt_allocator.setTargetDebtRatio(
+            strategy, target, sender=daddy
+        )
+
+    vault.add_strategy(strategy.address, sender=daddy)
+
+    with ape.reverts("!minimum"):
+        generic_debt_allocator.setTargetDebtRatio(
+            strategy, target, sender=daddy
+        )
+    
+    generic_debt_allocator.setMinimumChange(
+            strategy, minimum, sender=daddy
+        )
+
+    with ape.reverts("!max"):
+        generic_debt_allocator.setTargetDebtRatio(
+            strategy, int(10_001), sender=daddy
+        )
+
+    tx = generic_debt_allocator.setTargetDebtRatio(
+            strategy, target, sender=daddy
+        )
+
+    event = list(tx.decode_logs(generic_debt_allocator.SetTargetDebtRatio))[0]
+
+    assert event.strategy == strategy.address
+    assert event.targetRatio == target
+    assert event.totalDebtRatio == target
+    assert generic_debt_allocator.debtRatio() == target
+    assert generic_debt_allocator.configs(strategy) == (target, minimum)
+

--- a/tests/test_generic_debt_allocator.py
+++ b/tests/test_generic_debt_allocator.py
@@ -4,7 +4,9 @@ from utils.constants import ZERO_ADDRESS, MAX_INT
 
 
 def test_setup(generic_debt_allocator_factory, user, strategy, vault):
-    tx = generic_debt_allocator_factory.newGenericDebtAllocator(vault, user, sender=user)
+    tx = generic_debt_allocator_factory.newGenericDebtAllocator(
+        vault, user, sender=user
+    )
 
     events = list(tx.decode_logs(generic_debt_allocator_factory.NewDebtAllocator))
 
@@ -27,20 +29,14 @@ def test_set_minimum(generic_debt_allocator, daddy, vault, strategy, user):
     minimum = int(1e17)
 
     with ape.reverts("!governance"):
-        generic_debt_allocator.setMinimumChange(
-            strategy, minimum, sender=user
-        )
+        generic_debt_allocator.setMinimumChange(strategy, minimum, sender=user)
 
     with ape.reverts("!active"):
-        generic_debt_allocator.setMinimumChange(
-            strategy, minimum, sender=daddy
-        )
+        generic_debt_allocator.setMinimumChange(strategy, minimum, sender=daddy)
 
     vault.add_strategy(strategy.address, sender=daddy)
 
-    tx = generic_debt_allocator.setMinimumChange(
-            strategy, minimum, sender=daddy
-        )
+    tx = generic_debt_allocator.setMinimumChange(strategy, minimum, sender=daddy)
 
     event = list(tx.decode_logs(generic_debt_allocator.SetMinimumChange))[0]
 
@@ -56,34 +52,22 @@ def test_set_minimum(generic_debt_allocator, daddy, vault, strategy, user):
     target = int(5_000)
 
     with ape.reverts("!governance"):
-        generic_debt_allocator.setTargetDebtRatio(
-            strategy, target, sender=user
-        )
+        generic_debt_allocator.setTargetDebtRatio(strategy, target, sender=user)
 
     with ape.reverts("!active"):
-        generic_debt_allocator.setTargetDebtRatio(
-            strategy, target, sender=daddy
-        )
+        generic_debt_allocator.setTargetDebtRatio(strategy, target, sender=daddy)
 
     vault.add_strategy(strategy.address, sender=daddy)
 
     with ape.reverts("!minimum"):
-        generic_debt_allocator.setTargetDebtRatio(
-            strategy, target, sender=daddy
-        )
-    
-    generic_debt_allocator.setMinimumChange(
-            strategy, minimum, sender=daddy
-        )
+        generic_debt_allocator.setTargetDebtRatio(strategy, target, sender=daddy)
+
+    generic_debt_allocator.setMinimumChange(strategy, minimum, sender=daddy)
 
     with ape.reverts("!max"):
-        generic_debt_allocator.setTargetDebtRatio(
-            strategy, int(10_001), sender=daddy
-        )
+        generic_debt_allocator.setTargetDebtRatio(strategy, int(10_001), sender=daddy)
 
-    tx = generic_debt_allocator.setTargetDebtRatio(
-            strategy, target, sender=daddy
-        )
+    tx = generic_debt_allocator.setTargetDebtRatio(strategy, target, sender=daddy)
 
     event = list(tx.decode_logs(generic_debt_allocator.SetTargetDebtRatio))[0]
 
@@ -93,3 +77,99 @@ def test_set_minimum(generic_debt_allocator, daddy, vault, strategy, user):
     assert generic_debt_allocator.debtRatio() == target
     assert generic_debt_allocator.configs(strategy) == (target, minimum)
 
+
+def test_should_update_debt(
+    generic_debt_allocator, vault, strategy, daddy, deposit_into_vault, amount
+):
+    assert generic_debt_allocator.configs(strategy.address) == (0, 0)
+
+    with ape.reverts("!active"):
+        generic_debt_allocator.shouldUpdateDebt(strategy.address)
+
+    vault.add_strategy(strategy.address, sender=daddy)
+
+    with ape.reverts("!target"):
+        generic_debt_allocator.shouldUpdateDebt(strategy.address)
+
+    minimum = int(1)
+    target = int(5_000)
+
+    generic_debt_allocator.setMinimumChange(strategy, minimum, sender=daddy)
+    generic_debt_allocator.setTargetDebtRatio(strategy, target, sender=daddy)
+
+    # Vault has no assets so should be false.
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == False
+    assert bytes == ("No Change Needed").encode("utf-8")
+
+    deposit_into_vault(vault, amount)
+
+    # No max debt has been set so should be false.
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == False
+    assert bytes == ("No Change Needed").encode("utf-8")
+
+    vault.update_max_debt_for_strategy(strategy, MAX_INT, sender=daddy)
+
+    # Should now want to allocate 50%
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == True
+    print("got", bytes)
+    print("Made ", vault.update_debt.encode_input(strategy.address, amount // 2))
+    assert bytes == vault.update_debt.encode_input(strategy.address, amount // 2)
+
+    vault.update_debt(strategy, amount // 2, sender=daddy)
+
+    # Should now be false again once allocated
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == False
+    assert bytes == ("No Change Needed").encode("utf-8")
+
+    # Update the ratio to make true
+    generic_debt_allocator.setTargetDebtRatio(strategy, int(target + 1), sender=daddy)
+
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == True
+    assert bytes == vault.update_debt.encode_input(
+        strategy.address, int(amount * 5_001 // 10_000)
+    )
+
+    # Lower the max debt so its == to current debt
+    vault.update_max_debt_for_strategy(strategy, int(amount // 2), sender=daddy)
+
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == False
+    assert bytes == ("No Change Needed").encode("utf-8")
+
+    # Reset it.
+    vault.update_max_debt_for_strategy(strategy, MAX_INT, sender=daddy)
+
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == True
+    assert bytes == vault.update_debt.encode_input(
+        strategy.address, int(amount * 5_001 // 10_000)
+    )
+
+    # Increase the minimum_total_idle
+    vault.set_minimum_total_idle(vault.totalIdle(), sender=daddy)
+
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == False
+    assert bytes == ("").encode("utf-8")
+
+    vault.set_minimum_total_idle(0, sender=daddy)
+
+    # increase the minimum so its false again
+    generic_debt_allocator.setMinimumChange(strategy, int(1e30), sender=daddy)
+
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == False
+    assert bytes == ("").encode("utf-8")
+
+    # Lower the target and minimum
+    generic_debt_allocator.setMinimumChange(strategy, int(1), sender=daddy)
+    generic_debt_allocator.setTargetDebtRatio(strategy, int(target // 2), sender=daddy)
+
+    (bool, bytes) = generic_debt_allocator.shouldUpdateDebt(strategy.address)
+    assert bool == True
+    assert bytes == vault.update_debt.encode_input(strategy.address, amount // 4)


### PR DESCRIPTION
Create a basic debt allocator that can be cloned to for any V3 vault.

This is intended to serve as a trigger check for keepers that emulates the simple V2 logic of allocating to certain strategies by a ratio of the total assets.
