### PR TITLE
refactor: update ape

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -28,24 +28,21 @@ dependencies:
   - name: tokenized-strategy
     github: yearn/tokenized-strategy
     ref: v3.0.2
-    contracts_folder: src
+    config_override:
+      contracts_folder: src
     exclude:
      - test/**/*
 
   - name: periphery
     github: yearn/tokenized-strategy-periphery
     ref: master
-    contracts_folder: src
+    config_override:
+      contracts_folder: src
     exclude: 
      - test/**/*
 
 solidity:
   version: 0.8.18
-  import_remapping:
-    - "@openzeppelin/contracts=openzeppelin/v4.9.5"
-    - "@yearn-vaults=yearn-vaults/v3.0.2"
-    - "@tokenized-strategy=tokenized-strategy/v3.0.2"
-    - "@periphery=periphery/master"
 
 ethereum:
   local:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 black==22.3.0
-eth-ape==0.6.27
+eth-ape==0.8.12
 pysha3==1.0.2


### PR DESCRIPTION
Just working through upgrading Ape.

To get it to compile:

* `contracts_folder` now goes in `config_override` rather than exist in both places. Basically all config override goes in config override now.
* import remappings are wrong and unnecessary. The auto-remap works better, but if you wanted to include them, it is more performant to use the full source ID e.g.
```
- "@openzeppelin/contracts=openzeppelin/v4.9.5"
```
becomes
```
- "@openzeppelin=openzeppelin/v4.9.5"
```

It still works the original way for legacy reasons but it has to be too smart to figure out so it is not as performant.

For tests:

These are still failing for me, but I am trying to figure out why. Sometimes re-running them causes some of the tests to pass, like the state gets messed up or is not snapshotting correctly. In any case, the problem is always with `.return_value` it seems, so I am investigating there.